### PR TITLE
Original Item property & expandIconOnly option

### DIFF
--- a/demo/pages/events.html
+++ b/demo/pages/events.html
@@ -140,6 +140,7 @@
         { name: 'node:dblclick', args: ['Node'] },
         { name: 'node:selected', args: ['Node'] },
         { name: 'node:hover', args: ['Node'] },
+        { name: 'node:unhover', args: ['Node'] },
         { name: 'node:unselected', args: ['Node'] },
         { name: 'node:checked', args: ['Node'] },
         { name: 'node:unchecked', args: ['Node'] },
@@ -186,10 +187,13 @@
 
         mounted() {
           eventsList.forEach(e => {
-            this.$refs.tree.$on(e.name, this.initEventViewer(e))
+            this.$refs.tree.$on(e.name, (m, a) => {
+              this.initEventViewer(e)
+              console.log(m, a)
+            })
           })
-          this.$refs.tree.$on('node:selected', e => {
-            console.log(JSON.parse(JSON.stringify(e)))
+          this.$refs.tree.$on('node:selected', (e, a) => {
+            console.log(e, a)
           })
         },
 

--- a/demo/pages/events.html
+++ b/demo/pages/events.html
@@ -139,6 +139,7 @@
         { name: 'node:hidden', args: ['Node'] },
         { name: 'node:dblclick', args: ['Node'] },
         { name: 'node:selected', args: ['Node'] },
+        { name: 'node:hover', args: ['Node'] },
         { name: 'node:unselected', args: ['Node'] },
         { name: 'node:checked', args: ['Node'] },
         { name: 'node:unchecked', args: ['Node'] },
@@ -162,6 +163,7 @@
           data: getData(),
           filter: null,
           opts: {
+            expandIconOnly: true,
             fetchData: '/assets/data/events/{id}.json',
             checkbox: true,
             filter: {
@@ -185,6 +187,9 @@
         mounted() {
           eventsList.forEach(e => {
             this.$refs.tree.$on(e.name, this.initEventViewer(e))
+          })
+          this.$refs.tree.$on('node:selected', e => {
+            console.log(JSON.parse(JSON.stringify(e)))
           })
         },
 
@@ -226,7 +231,7 @@
                 )
               )
 
-              console.log(arguments)
+              // console.log(arguments)
             }
           }
         }
@@ -239,7 +244,16 @@
               {
                 "text": "Introduction",
                 "isBatch": true,
-                "id": 1
+                "id": 1,
+                "bloublou": "asjdh",
+                "fields": ["akjhasdkjhda"],
+                "children": [
+                  {
+                    "text": "Introduction",
+                    "isBatch": true,
+                    "id": 1,
+                  }
+                ]
               },
               {
                 "text": "Part I: Fundamentals",

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -19,11 +19,11 @@
         tabindex="1"
         ref="anchor"
         @focus="onNodeFocus"
-        @dblclick="tree.$emit('node:dblclick', node)"
-        @mouseover="tree.$emit('node:hover', node)"
-        @mouseout="tree.$emit('node:unhover', node)"
-        @mousedown="tree.$emit('node:mousedown', node)"
-        @mouseup="tree.$emit('node:mouseup', node)">
+        @dblclick="tree.$emit('node:dblclick', node, $event)"
+        @mouseenter.stop="tree.$emit('node:hover', node, $event)"
+        @mouseleave.stop="tree.$emit('node:unhover', node, $event)"
+        @mousedown="tree.$emit('node:mousedown', node, $event)"
+        @mouseup="tree.$emit('node:mouseup', node, $event)">
           <node-content :node="node" />
       </span>
     </div>
@@ -312,6 +312,7 @@
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
+    background: red;
   }
 
   .tree-node.selected .tree-anchor {

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -312,7 +312,6 @@
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
-    background: red;
   }
 
   .tree-node.selected .tree-anchor {

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -1,6 +1,6 @@
 <template>
   <li class="tree-node" :class="nodeClass">
-    <div class="tree-content" :style="{'padding-left': paddingLeft}" @click.stop="select">
+    <div class="tree-content" :style="{'padding-left': paddingLeft}">
       <i
         class="tree-arrow"
         :class="{'expanded': node.states.expanded, 'has-child': node.children.length || node.isBatch}"
@@ -14,18 +14,21 @@
         @mouseup.stop="check">
       </i>
 
-      <span
-        class="tree-anchor"
-        tabindex="1"
-        ref="anchor"
-        @focus="onNodeFocus"
-        @dblclick="tree.$emit('node:dblclick', node, $event)"
-        @mouseenter.stop="tree.$emit('node:hover', node, $event)"
-        @mouseleave.stop="tree.$emit('node:unhover', node, $event)"
-        @mousedown="tree.$emit('node:mousedown', node, $event)"
-        @mouseup="tree.$emit('node:mouseup', node, $event)">
-          <node-content :node="node" />
-      </span>
+      <div>
+        <span
+          class="tree-anchor"
+          tabindex="1"
+          ref="anchor"
+          @click.stop="select"
+          @focus="onNodeFocus"
+          @dblclick="tree.$emit('node:dblclick', node, $event)"
+          @mouseenter.stop="tree.$emit('node:hover', node, $event)"
+          @mouseleave.stop="tree.$emit('node:unhover', node, $event)"
+          @mousedown="tree.$emit('node:mousedown', node, $event)"
+          @mouseup="tree.$emit('node:mouseup', node, $event)">
+            <node-content :node="node" />
+        </span>
+      </div>
     </div>
 
     <transition name="l-fade">
@@ -43,6 +46,14 @@
           </node>
       </ul>
     </transition>
+
+    <div
+      @mouseenter.stop="tree.$emit('sa:hover', node, $event)"
+      @mouseleave.stop="tree.$emit('sa:unhover', node, $event)"
+      @mousedown="tree.$emit('sa:mousedown', node, $event)"
+      @mouseup="tree.$emit('sa:mouseup', node, $event)"
+      class="sub-area">
+    </div>
   </li>
 </template>
 
@@ -186,6 +197,10 @@
 </script>
 
 <style>
+  .sub-area {
+    width: 100%;
+    height: 7px;
+  }
   .tree-node {
     white-space: nowrap;
     display: flex;

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -1,6 +1,6 @@
 <template>
   <li class="tree-node" :class="nodeClass">
-    <div class="tree-content" :style="{'padding-left': paddingLeft}" @mouseup.stop="select">
+    <div class="tree-content" :style="{'padding-left': paddingLeft}" @mouseup.stop="e => options.selectedArrowOnly || select(e)">
       <i
         class="tree-arrow"
         :class="{'expanded': node.states.expanded, 'has-child': node.children.length || node.isBatch}"
@@ -14,15 +14,14 @@
         @mouseup.stop="check">
       </i>
 
-      <a
-        href="javascript:void(0)"
+      <span
         class="tree-anchor"
         tabindex="1"
         ref="anchor"
         @focus="onNodeFocus"
         @dblclick="tree.$emit('node:dblclick', node)">
           <node-content :node="node" />
-      </a>
+      </span>
     </div>
 
     <transition name="l-fade">
@@ -62,7 +61,9 @@
         state: this.node.states
       }
     },
-
+    created() {
+      console.log(JSON.parse(JSON.stringify(this.options)))
+    },
     computed: {
       paddingLeft() {
         return this.node.depth * this.options.paddingLeft + 'px'

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -19,7 +19,8 @@
         tabindex="1"
         ref="anchor"
         @focus="onNodeFocus"
-        @dblclick="tree.$emit('node:dblclick', node)">
+        @dblclick="tree.$emit('node:dblclick', node)"
+        @mouseover="tree.$emit('node:hover', node)">
           <node-content :node="node" />
       </span>
     </div>

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -1,6 +1,6 @@
 <template>
   <li class="tree-node" :class="nodeClass">
-    <div class="tree-content" :style="{'padding-left': paddingLeft}" @mouseup.stop="select">
+    <div class="tree-content" :style="{'padding-left': paddingLeft}" @click.stop="select">
       <i
         class="tree-arrow"
         :class="{'expanded': node.states.expanded, 'has-child': node.children.length || node.isBatch}"

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -119,7 +119,7 @@
         }
 
         if (opts.checkbox && opts.checkOnSelect) {
-          if (!opts.parentSelect && this.hasChildren() && !opts.selectedArrowOnly) {
+          if (!opts.parentSelect && this.hasChildren() && !opts.expandIconOnly) {
             return this.toggleExpand()
           }
 
@@ -128,7 +128,7 @@
 
         // 'parentSelect' behaviour.
         // For nodes which has a children list we have to expand/collapse
-        if (!opts.parentSelect && this.hasChildren() && !opts.selectedArrowOnly) {
+        if (!opts.parentSelect && this.hasChildren() && !opts.expandIconOnly) {
           this.toggleExpand()
         }
 

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -20,7 +20,10 @@
         ref="anchor"
         @focus="onNodeFocus"
         @dblclick="tree.$emit('node:dblclick', node)"
-        @mouseover="tree.$emit('node:hover', node)">
+        @mouseover="tree.$emit('node:hover', node)"
+        @mouseout="tree.$emit('node:unhover', node)"
+        @mousedown="tree.$emit('node:mousedown', node)"
+        @mouseup="tree.$emit('node:mouseup', node)">
           <node-content :node="node" />
       </span>
     </div>

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -201,7 +201,6 @@
   .sub-area {
     width: auto;
     height: 7px;
-    background: red;
   }
   .tree-node {
     white-space: nowrap;

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -31,6 +31,15 @@
       </div>
     </div>
 
+    <div
+      @mouseenter.stop="tree.$emit('sa:hover', node, $event)"
+      @mouseleave.stop="tree.$emit('sa:unhover', node, $event)"
+      @mousedown="tree.$emit('sa:mousedown', node, $event)"
+      @mouseup="tree.$emit('sa:mouseup', node, $event)"
+      class="sub-area"
+      :style="{'margin-left': paddingLeft}">
+    </div>
+
     <transition name="l-fade">
       <ul
         v-if="hasChildren() && state.expanded"
@@ -46,14 +55,6 @@
           </node>
       </ul>
     </transition>
-
-    <div
-      @mouseenter.stop="tree.$emit('sa:hover', node, $event)"
-      @mouseleave.stop="tree.$emit('sa:unhover', node, $event)"
-      @mousedown="tree.$emit('sa:mousedown', node, $event)"
-      @mouseup="tree.$emit('sa:mouseup', node, $event)"
-      class="sub-area">
-    </div>
   </li>
 </template>
 
@@ -198,8 +199,9 @@
 
 <style>
   .sub-area {
-    width: 100%;
+    width: auto;
     height: 7px;
+    background: red;
   }
   .tree-node {
     white-space: nowrap;

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -1,6 +1,6 @@
 <template>
   <li class="tree-node" :class="nodeClass">
-    <div class="tree-content" :style="{'padding-left': paddingLeft}" @mouseup.stop="e => options.selectedArrowOnly || select(e)">
+    <div class="tree-content" :style="{'padding-left': paddingLeft}" @mouseup.stop="select">
       <i
         class="tree-arrow"
         :class="{'expanded': node.states.expanded, 'has-child': node.children.length || node.isBatch}"
@@ -119,7 +119,7 @@
         }
 
         if (opts.checkbox && opts.checkOnSelect) {
-          if (!opts.parentSelect && this.hasChildren()) {
+          if (!opts.parentSelect && this.hasChildren() && !opts.selectedArrowOnly) {
             return this.toggleExpand()
           }
 
@@ -128,7 +128,7 @@
 
         // 'parentSelect' behaviour.
         // For nodes which has a children list we have to expand/collapse
-        if (!opts.parentSelect && this.hasChildren()) {
+        if (!opts.parentSelect && this.hasChildren() && !opts.selectedArrowOnly) {
           this.toggleExpand()
         }
 

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -61,9 +61,7 @@
         state: this.node.states
       }
     },
-    created() {
-      console.log(JSON.parse(JSON.stringify(this.options)))
-    },
+
     computed: {
       paddingLeft() {
         return this.node.depth * this.options.paddingLeft + 'px'

--- a/src/components/TreeRoot.vue
+++ b/src/components/TreeRoot.vue
@@ -36,7 +36,7 @@
   import Tree from '@/lib/Tree'
 
   const defaults = {
-    selectedArrowOnly: false,
+    expandIconOnly: false,
     multiple: true,
     checkbox: false,
     checkOnSelect: false,

--- a/src/components/TreeRoot.vue
+++ b/src/components/TreeRoot.vue
@@ -36,6 +36,7 @@
   import Tree from '@/lib/Tree'
 
   const defaults = {
+    selectedArrowOnly: false,
     multiple: true,
     checkbox: false,
     checkOnSelect: false,

--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -11,6 +11,7 @@ export default class Node {
 
     this.id = item.id || uuidV4()
     this.states = item.state || {}
+    this.item = item.item
 
     this.showChildren = true
     this.children = item.children || []
@@ -556,6 +557,7 @@ export default class Node {
       text: this.text,
       data: this.data,
       state: this.states,
+      item: this.item,
       children: this.children
     }
   }

--- a/src/utils/treeParser.js
+++ b/src/utils/treeParser.js
@@ -31,7 +31,7 @@ function convertNames (obj, names) {
     state: obj[names.state],
     data: obj[names.data],
     isBatch: obj[names.isBatch],
-    item: obj
+    item: { ...obj, [names.children]: undefined }
   }
 }
 

--- a/src/utils/treeParser.js
+++ b/src/utils/treeParser.js
@@ -19,7 +19,8 @@ const defaultPropertyNames = {
   children: 'children',
   state: 'state',
   data: 'data',
-  isBatch: 'isBatch'
+  isBatch: 'isBatch',
+  item: 'item'
 }
 
 function convertNames (obj, names) {
@@ -29,7 +30,8 @@ function convertNames (obj, names) {
     children: obj[names.children],
     state: obj[names.state],
     data: obj[names.data],
-    isBatch: obj[names.isBatch]
+    isBatch: obj[names.isBatch],
+    item: obj
   }
 }
 


### PR DESCRIPTION
Now we can get the original object with the item property on event  
With expandIconOnly option, the a Node expand only when you click on the arrow