### PR TITLE
Recursion fix & improvement

### DIFF
--- a/docs/hexo/source/index.md
+++ b/docs/hexo/source/index.md
@@ -80,6 +80,7 @@ To register the library you can choose between the 3 methods I mention above.
 | **checkbox**           | Boolean   | false   | `checkbox` mode. It shows checkboxes for every node           |
 | **checkOnSelect**      | Boolean   | false   | For `checkbox` mode only. Node will have `checked` state when user clicks either text or checkbox |
 | **autoCheckChildren**  | Boolean   | true    | For `checkbox` mode only. Children will have the same `checked` state as their parent. |
+| **autoDisableChildren**| Boolean   | true    | Toggles whether children will have the same `disabled` state as their parent. |
 | **parentSelect**       | Boolean   | false   | By clicking node which has children it expands node. i.e we have two ways to expand/collapse node: by clicking on arrow and on text |
 | **keyboardNavigation** | Boolean   | true    | Allows user to navigate tree using keyboard |
 | **propertyNames**      | Object    | -       | This options allows the default tree's structure to be redefined. [See example](#Redefine-Structure) |

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -320,11 +320,11 @@
     user-select: none;
   }
 
-  .tree-node.selected .tree-anchor {
+  .tree-node.selected > .tree-content > .tree-anchor {
     outline: none;
   }
 
-  .tree-node.disabled .tree-anchor {
+  .tree-node.disabled > .tree-content > .tree-anchor {
     color: #989191;
     background: #fff;
     opacity: .6;

--- a/src/components/TreeRoot.vue
+++ b/src/components/TreeRoot.vue
@@ -44,6 +44,7 @@
     checkbox: false,
     checkOnSelect: false,
     autoCheckChildren: true,
+    autoDisableChildren: true,
     parentSelect: false,
     keyboardNavigation: true,
     paddingLeft: 24,

--- a/src/lib/Tree.js
+++ b/src/lib/Tree.js
@@ -184,7 +184,7 @@ export default class Tree {
         if (this.options.autoCheckChildren) {
           if (node.checked()) {
             node.recurseDown(child => {
-              child.check()
+              child.state('checked', true)
             })
           }
         }

--- a/src/lib/Tree.js
+++ b/src/lib/Tree.js
@@ -181,10 +181,12 @@ export default class Tree {
         node.append(children)
         node.isBatch = false
 
-        if (node.checked()) {
-          node.recurseDown(child => {
-            child.state('checked', true)
-          })
+        if (this.options.autoCheckChildren) {
+          if (node.checked()) {
+            node.recurseDown(child => {
+              child.check()
+            })
+          }
         }
 
         this.$emit('tree:data:received', node)

--- a/src/lib/Tree.js
+++ b/src/lib/Tree.js
@@ -256,7 +256,7 @@ export default class Tree {
         }
       }
 
-      if (node.disabled()) {
+      if (this.options.autoDisableChildren && node.disabled()) {
         node.recurseDown(child => {
           child.state('disabled', true)
         })


### PR DESCRIPTION
Hi

This PR addresses a bug where lazily fetched nodes where checked even if `autoCheckChildren` was false, and adds a new property, `autoDisableChildren`, which has a similar effect, but affecting the `disabled` state instead.