### PR TITLE
Passing destination node and drop position to node:dragging:finish

### DIFF
--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -496,7 +496,7 @@ export default class Node {
 
     clone.state('dragging', false)
     this.state('dragging', false)
-    this.$emit('dragging:finish')
+    this.$emit('dragging:finish', destination, destinationPosition)
 
     if (clone.state('selected')) {
       tree.selectedNodes.remove(this)

--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -496,7 +496,8 @@ export default class Node {
 
     clone.state('dragging', false)
     this.state('dragging', false)
-    this.$emit('dragging:finish', destination, destinationPosition)
+    // need to call emit on the clone, because we need to have node.parent filled in the event listener
+    clone.$emit('dragging:finish', destination, destinationPosition)
 
     if (clone.state('selected')) {
       tree.selectedNodes.remove(this)


### PR DESCRIPTION
This pull request should fix bug #109 - passing destinationNode and drop position to event listeners on `node:dragging:finish`

However event handler's prototype in the documentation should be changed from 
(destinationNode, dropPosition) to (sourceNode, destinationNode, dropPosition) 
as `Node.$emit` always adds `this` as the first argument to events.
