### PR TITLE
Fixing duplicate :key

### DIFF
--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -479,6 +479,8 @@ export default class Node {
     clone.id = this.id
     tree.__silence = true
 
+    this.remove()
+
     if (destinationPosition === 'drag-on') {
       tree.append(destination, clone)
     } else if (destinationPosition === 'drag-below') {
@@ -486,8 +488,6 @@ export default class Node {
     } else if (destinationPosition === 'drag-above') {
       tree.before(destination, clone)
     }
-
-    this.remove()
 
     destination.refreshIndeterminateState()
 


### PR DESCRIPTION
Sometimes after drag/dropping a node a "duplicate :key" error is raised by vuejs.
The error stems from v-for on TreeNode:

&lt;TreeNode
            v-for="node in matches"
            v-if="node.visible()"
            :key="node.id"
            :node="node"
            :options="opts"
          />
where for a small amount of time both the old node and the new one are present.

This fix changes the order of removing/adding element upon drop - at first the
previous element is removed and subsequently a new one is added.
Seems to fix this problem.