### PR TITLE
Added ability to update data through an update method

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -24,6 +24,7 @@
       <li class="demo-item"><a href="pages/vuex.html">Vuex Integration</a></li>
       <li class="demo-item"><a href="pages/exporting.html">Exporting</a></li>
       <li class="demo-item"><a href="pages/dnd.html">Drag & Drop</a></li>
+      <li class="demo-item"><a href="pages/updating.html">Updating</a></li>
     </div>
   </body>
 </html>

--- a/demo/pages/updating.html
+++ b/demo/pages/updating.html
@@ -26,7 +26,7 @@
           Basic example
         </div>
         <div class="example-tree">
-          <tree ref="tree" :data="treeData" @node:selected="selectNode" />
+          <tree ref="tree" :data="treeData" />
         </div>
       </div>
 

--- a/demo/pages/updating.html
+++ b/demo/pages/updating.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <title>Liquor Tree: Updating</title>
+  <link rel="stylesheet" href="../assets/style.css">
+  <script src="../assets/menu.js"></script>
+
+  <!-- first import Vue -->
+  <!-- <script src="https://unpkg.com/vue/dist/vue.js"></script> -->
+  <script src="../assets/vue.js"></script>
+  <script src="/liquor-tree.umd.js"></script>
+</head>
+
+<body>
+  <div class="hello">
+    Updating.
+  </div>
+
+  <div id="app">
+    <div class="examples">
+      <div class="example">
+        <div class="example-description">
+          Basic example
+        </div>
+        <div class="example-tree">
+          <tree ref="tree" :data="treeData" @node:selected="selectNode" />
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <script>
+    new Vue({
+      el: '#app',
+      data: () => ({
+        treeData: [
+          { text: 'Item 1' },
+          { text: 'Item 2' },
+          { text: 'Item 3', state: { selected: true } },
+          { text: 'Item 4' }
+        ]
+      }),
+      mounted() {
+        this.$nextTick(() => {
+          this.$refs.tree.update('Item 1', node => {
+            return { text: 'New Item!' };
+          });
+        })
+      }
+    })
+  </script>
+
+</body>
+
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "liquor-tree",
-  "version": "0.2.47",
+  "version": "0.2.60",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -315,13 +315,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.0.tgz",
       "integrity": "sha512-PyWcbX0W4r4GcgXLI0Vu4jyJ/Erueo3PwjgvQcOmWAOBW0ObhzBBciEX+sHvjkNE0umI6nqD192FDKvYZTL91A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@types/babylon": {
       "version": "6.16.2",
       "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.2.tgz",
       "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/babel-types": "*"
       }
@@ -2690,6 +2692,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -3491,6 +3494,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -3576,6 +3580,7 @@
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
       "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/babel-types": "^7.0.0",
         "@types/babylon": "^6.16.2",
@@ -5614,7 +5619,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6029,7 +6035,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6085,6 +6092,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6128,12 +6136,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6142,6 +6152,7 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -6223,7 +6234,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "get-stream": {
       "version": "3.0.0",
@@ -6625,7 +6637,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "hoist-non-react-statics": {
       "version": "1.2.0",
@@ -8156,7 +8169,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -8862,7 +8876,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "map-visit": {
       "version": "1.0.0",
@@ -9039,13 +9054,15 @@
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
       "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "mime-types": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
+      "optional": true,
       "requires": {
         "mime-db": "~1.30.0"
       }
@@ -9426,13 +9443,15 @@
           "version": "1.36.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
           "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.20",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
           "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.36.0"
           }
@@ -11283,7 +11302,8 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.2.tgz",
       "integrity": "sha1-U659nSm7A89WRJOgJhCfVMR/XyY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pug-filters": {
       "version": "2.1.5",
@@ -11436,7 +11456,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.3.tgz",
       "integrity": "sha1-mBYmB7D86eJU1CfzOYelrucWi9o=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pug-strip-comments": {
       "version": "1.0.2",
@@ -11452,7 +11473,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.5.tgz",
       "integrity": "sha512-rJlH1lXerCIAtImXBze3dtKq/ykZMA4rpO9FnPcIgsWcxZLOvd8zltaoeOVFyBSSqCkhhJWbEbTMga8UxWUUSA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pump": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liquor-tree",
   "description": "A Vue.js tree component.",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "author": "Kostiantyn <phlyze@gmail.com>",
   "library": "LiquorTree",
   "homepage": "https://amsik.github.io/liquor-tree/",

--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -81,6 +81,15 @@ export default class Node {
     }
   }
 
+  setData (data) {
+    this.data = {
+      ...this.data,
+      ...data
+    }
+
+    return this.tree.data = this.data;
+  }
+
   state (name, value) {
     if (undefined === value) {
       return this.states[name]

--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -81,13 +81,12 @@ export default class Node {
     }
   }
 
-  setData (data) {
-    this.data = {
-      ...this.data,
-      ...data
-    }
+  setData (data = {}) {
+    this.data = Object.assign({}, this.data, data);
 
-    return this.tree.data = this.data;
+    this.$emit('updated', this.data);
+
+    return this.data;
   }
 
   state (name, value) {

--- a/src/lib/Tree.js
+++ b/src/lib/Tree.js
@@ -682,6 +682,14 @@ export default class Tree {
     return new Selection(this, [result[0]])
   }
 
+  update (criteria, callback) {
+    let nodes = this.find(criteria);
+
+    nodes.forEach(node => node.setData(callback(node)));
+
+    return nodes;
+  }
+
   getNodeById (id) {
     let targetNode = null
 

--- a/src/mixins/DndMixin.js
+++ b/src/mixins/DndMixin.js
@@ -159,6 +159,8 @@ export default {
         if (this.$$dropDestination && this.tree.isNode(this.$$dropDestination) && this.$$dropDestination.vm) {
           updateHelperClasses(this.$$dropDestination.vm.$el, null)
 
+          this.draggableNode.node.parent = this.$$dropDestination
+
           const cbResult = callDndCb(
             [this.draggableNode.node, this.$$dropDestination, dropPosition],
             this.tree.options.dnd,

--- a/src/mixins/TreeMixin.js
+++ b/src/mixins/TreeMixin.js
@@ -182,6 +182,10 @@ export default {
       return this.tree.find(criteria, true)
     },
 
+    update (criteria, callback) {
+      return this.tree.update(criteria, callback);
+    },
+
     expandAll () {
       return this.tree.expandAll()
     },


### PR DESCRIPTION
I have quite frequently ran into a situation where I was using the "data" object on a node for various reasons. I ran into a situations where I wanted to update the X amount of nodes at the same time so I would first have to find them, loop through them and update a specific value and this approach felt cumbersome. 

So I thought it would be nice to have a method to update the data object on a given node. The reason why it's just the data object and not other things is because that's the only object that can be safely updated without unintended consequences + we already have other helpers for nodes like **select**, **unselect** etc to update the state. 

The way you use it is like this:
```javascript
this.$refs.tree.update('Item 1', node => {
    return { path: '/path/to/node' }
});
```

The first argument of the `update` method is exactly the same as the argument in the `find` method where it's the criteria. So it can be RegExp or just a string to match the text. Second argument is callback which gives you access to each of the nodes that matched the criteria. The return statement in the callback is what is added to the data object of the node. So you could even override the text by simply doing: 
```javascript
this.$refs.tree.update('Item 1', node => {
    return { text: 'Item 2' }
});
```