### PR TITLE
Correct tree context absence error

### DIFF
--- a/src/lib/Node.js
+++ b/src/lib/Node.js
@@ -24,7 +24,7 @@ export default class Node {
     })
 
     if (!tree) {
-      throw new Error('Node must has a Tree context!')
+      throw new Error('Node must have a Tree context!')
     }
 
     this.tree = tree

--- a/test/lib/Node.spec.js
+++ b/test/lib/Node.spec.js
@@ -13,7 +13,7 @@ const tree = new Tree(vm)
 describe('Lib: Node.js', () => {
   it('node constructor arguments', () => {
     expect(() => { new Node() }).toThrowError('Node can not be empty')
-    expect(() => { new Node(null, {}) }).toThrowError('Node must has a Tree context!')
+    expect(() => { new Node(null, {}) }).toThrowError('Node must have a Tree context!')
 
     // TODO: whether to check Tree instance?
   })


### PR DESCRIPTION
Should be ‘Node must have a Tree context’