### PR TITLE
use computed properties in v-for declarations

### DIFF
--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -29,14 +29,11 @@
         v-if="hasChildren() && node.states.expanded"
         class="tree-children">
           <node
-            v-for="child in node.children"
-            v-if="child && child.visible()"
-
+            v-for="child in visibleChildren"
             :key="child.id"
             :node="child"
             :options="options"
-            >
-          </node>
+          />
       </ul>
     </transition>
   </li>
@@ -93,6 +90,12 @@
         }
 
         return classes
+      },
+
+      visibleChildren() {
+        return this.node.children.filter(function(child) {
+          return child && child.visible()
+        })
       }
     },
 

--- a/src/components/TreeRoot.vue
+++ b/src/components/TreeRoot.vue
@@ -7,9 +7,7 @@
       <ul class="tree-root" @dragstart="onDragStart">
         <template v-if="opts.filter.plainList && matches.length > 0">
           <TreeNode
-            v-for="node in matches"
-            v-if="node.visible()"
-
+            v-for="node in visibleMatches"
             :key="node.id"
             :node="node"
             :options="opts"
@@ -17,9 +15,7 @@
         </template>
         <template v-else>
           <TreeNode
-            v-for="node in model"
-            v-if="node && node.visible()"
-
+            v-for="node in visibleModel"
             :key="node.id"
             :node="node"
             :options="opts"
@@ -111,6 +107,20 @@
       }
     },
 
+    computed: {
+      visibleModel() {
+        return this.model.filter(function(node) {
+          return node && node.visible()
+        }) 
+      },
+
+      visibleMatches() {
+        return this.matches.filter(function(node) {
+          return node && node.visible()
+        })
+      }
+    },
+
     data () {
       // we should not mutating a prop directly...
       // that's why we have to create a new object
@@ -124,7 +134,7 @@
       )
 
       return {
-        model: null,
+        model: [],
         tree: null,
         loading: false,
         opts,


### PR DESCRIPTION
I added computed properties where there were previously nodes that had both v-for declarations AND v-if declarations.

This fixes a Vue anti-pattern referenced [here](https://vuejs.org/v2/style-guide/#Avoid-v-if-with-v-for-essential) that will improve performance and fix the linting error.

This is my first contribution. I tried to make my changes consistent with the style of the repo. Unit tests pass, and I was able to verify in the dev environment that everything works as before.