### PR TITLE
implement selectable state on TreeNode

### DIFF
--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -20,7 +20,9 @@
       <i
         v-if="options.checkbox"
         class="tree-checkbox"
-        :class="{'checked': node.states.checked, 'indeterminate': node.states.indeterminate}"
+        :class="{'checked': node.states.checked,
+                 'indeterminate': node.states.indeterminate,
+                 'disabled': !node.states.selectable}"
         @click.stop="check"
       />
 
@@ -89,6 +91,7 @@
           'has-child': hasChildren,
           'expanded': hasChildren && state.expanded,
           'selected': state.selected,
+          'selectable': state.selectable,
           'disabled': state.disabled,
           'matched': state.matched,
           'dragging': state.dragging,
@@ -122,6 +125,7 @@
       },
 
       check() {
+        if (!this.node.selectable()) { return }
         if (this.node.checked()) {
           this.node.uncheck()
         } else {


### PR DESCRIPTION
Fixes #193. This pull request adds a `selectable` class on a `TreeNode` when `selectable` is being set in the node's state. Additionally, TreeNode checkbox will be disabled when tree node is not selectable.